### PR TITLE
No need to fetch all associations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
-on: push
 name: Build & Test
+on:
+  push:
+    branches: [ "main"]
+  pull_request:
+    branches: [ "main"]
 env:
   MIX_ENV: test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.2.5
+
+### Improvements
+
+* Was previously loading all associations, which caused timeouts for records with large amounts of associated records.
+* Tests are now run on PRs instead of only pushes against main.
+
 ## v0.2.4
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add `dumper` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:dumper, "~> 0.2.4"}
+    {:dumper, "~> 0.2.5"}
   ]
 end
 ```

--- a/lib/dumper/live_dashboard_page.ex
+++ b/lib/dumper/live_dashboard_page.ex
@@ -75,7 +75,7 @@ defmodule Dumper.LiveDashboardPage do
   def handle_params(%{"action" => "show_record"} = params, _uri, socket) do
     repo = socket.assigns.repo
     module = to_module(params["module"])
-    record = module |> repo.get!(params["id"]) |> repo.preload(module.__schema__(:associations))
+    record = repo.get!(module, params["id"])
 
     associations =
       Enum.map(module.__schema__(:associations), fn assoc ->

--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,7 @@
 defmodule Dumper.MixProject do
   use Mix.Project
 
-  @version "0.2.4"
+  @version "0.2.5"
   @url "https://github.com/adobe/elixir-dumper"
 
   def project do


### PR DESCRIPTION
Fetching all the associations was unnecessary, since we fetch paginated associations immediately after.  Nothing in the rendering depends on them being populated, and if we needed, we could get them from the `@associations` assigns.

Separately, run tests on PRs against `main`, not just on pushes to `main`.